### PR TITLE
COMP: Remove non-ASCII character.

### DIFF
--- a/include/itkSpeedFunctionToPathFilter.h
+++ b/include/itkSpeedFunctionToPathFilter.h
@@ -52,7 +52,7 @@ namespace itk
  *     Cambridge Press, 2nd edition, 1999.
  * [2] J. Andrews and J. Sethian. Fast marching methods for the continuous
  *     traveling salesman problem. Proceedings of the National Academy of
- *     Sciences (PNAS), 104(4):11181123, 2007.
+ *     Sciences (PNAS), 104(4):1118 1123, 2007.
  *
  * \author Dan Mueller, Queensland University of Technology, dan.muel[at]gmail.com
  *


### PR DESCRIPTION
This interferes with itk_doxy2swig.py.

FAILED: cd /home/matt/bin/ITKMinimalPathExtraction-GCC-MinSizeRel/Wrapping/Modules/MinimalPathExtraction && /usr/bin/python /home/matt/src/ITK3/Wrapping/Generators/Doc/itk_doxy2swig.py /home/matt/bin/ITKMinimalPathExtraction-GCC-MinSizeRel/Wrapping/Modules/MinimalPathExtraction/Doc/itkSpeedFunctionToPathFilter.conf /home/matt/bin/ITKMinimalPathExtraction-GCC-MinSizeRel/Wrapping/Typedefs/itkSpeedFunctionToPathFilter_doc.i
Traceback (most recent call last):
  File "/home/matt/src/ITK3/Wrapping/Generators/Doc/itk_doxy2swig.py", line 128, in <module>
    main(sys.argv[1], sys.argv[2])
  File "/home/matt/src/ITK3/Wrapping/Generators/Doc/itk_doxy2swig.py", line 122, in main
    d2s_dir(in_dir_name, out_swig_i)
  File "/home/matt/src/ITK3/Wrapping/Generators/Doc/itk_doxy2swig.py", line 110, in d2s_dir
    d2s.write_to_file(output2)
  File "/home/matt/src/ITK3/Wrapping/Generators/Doc/itk_doxy2swig.py", line 28, in write_to_file
    file.write("".join(self.clean_pieces(self.pieces)))
UnicodeEncodeError: 'ascii' codec can't encode character u'\x96' in position 1527: ordinal not in range(128)