### PR TITLE
COMP: Add missing vector header include.

### DIFF
--- a/include/itkSpeedFunctionPathInformation.h
+++ b/include/itkSpeedFunctionPathInformation.h
@@ -19,9 +19,11 @@
 
 #include "itkLightObject.h"
 
+#include <vector>
 
 namespace itk
 {
+
 /** \class SpeedFunctionPathInformation
  * \brief  PathInfo class for encapsulating information about a path
  * for a SpeedFunctionToPathFilter Object.
@@ -41,7 +43,6 @@ namespace itk
  *
  * \ingroup MinimalPathExtraction
  */
-
 template <typename TPoint>
 class SpeedFunctionPathInformation :
   public LightObject


### PR DESCRIPTION
Without this include, a compilation error results on some compilers.