### PR TITLE
COMP: Add missing ObjectFactory header.

### DIFF
--- a/include/itkSpeedFunctionPathInformation.h
+++ b/include/itkSpeedFunctionPathInformation.h
@@ -18,6 +18,7 @@
 #define itkSpeedFunctionPathInformation_h
 
 #include "itkLightObject.h"
+#include "itkObjectFactory.h"
 
 #include <vector>
 


### PR DESCRIPTION
A missing header error can occur on Ubuntu 14.04.