### PR TITLE
STYLE: Use Macro for Function Deletion

### DIFF
--- a/include/itkArrivalFunctionToPathFilter.h
+++ b/include/itkArrivalFunctionToPathFilter.h
@@ -82,8 +82,7 @@ protected:
   ~ArrivalFunctionToPathCommand(){}
 
 private:
-  ArrivalFunctionToPathCommand( const Self& );
-  void operator = ( const Self& );
+  ITK_DISALLOW_COPY_AND_ASSIGN(ArrivalFunctionToPathCommand);
 
   typename FilterType::Pointer m_Filter;
 };
@@ -236,8 +235,7 @@ protected:
   unsigned int m_CurrentOutput;
 
 private:
-  ArrivalFunctionToPathFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(ArrivalFunctionToPathFilter);
 };
 
 } // end namespace itk

--- a/include/itkIterateNeighborhoodOptimizer.h
+++ b/include/itkIterateNeighborhoodOptimizer.h
@@ -108,8 +108,7 @@ protected:
   void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
 
 private:
-  IterateNeighborhoodOptimizer(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(IterateNeighborhoodOptimizer);
 
   bool                 m_Stop;
   bool                 m_Maximize;

--- a/include/itkPhysicalCentralDifferenceImageFunction.h
+++ b/include/itkPhysicalCentralDifferenceImageFunction.h
@@ -138,8 +138,7 @@ protected:
   void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
 
 private:
-  PhysicalCentralDifferenceImageFunction( const Self& ); //purposely not implemented
-  void operator=( const Self& ); //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(PhysicalCentralDifferenceImageFunction);
 
   typename InterpolateImageFunctionType::Pointer m_Interpolator;
 

--- a/include/itkSingleImageCostFunction.h
+++ b/include/itkSingleImageCostFunction.h
@@ -134,8 +134,7 @@ protected:
   void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE;
 
 private:
-  SingleImageCostFunction(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(SingleImageCostFunction);
 
   ImageConstPointer                           m_Image;
   typename InterpolatorType::Pointer          m_Interpolator;

--- a/include/itkSpeedFunctionPathInformation.h
+++ b/include/itkSpeedFunctionPathInformation.h
@@ -101,8 +101,7 @@ protected:
 
 
 private:
-  SpeedFunctionPathInformation( const Self& ); //purposely not implemented
-  void operator=( const Self& ); //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(SpeedFunctionPathInformation);
 };
 
 

--- a/include/itkSpeedFunctionToPathFilter.h
+++ b/include/itkSpeedFunctionToPathFilter.h
@@ -169,8 +169,7 @@ protected:
   InputImagePointer                                    m_CurrentArrivalFunction;
 
 private:
-  SpeedFunctionToPathFilter( const Self& ); //purposely not implemented
-  void operator=( const Self& ); //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(SpeedFunctionToPathFilter);
 
 };
 


### PR DESCRIPTION
@hjmjohnson
Use ITK_DISALLOW_COPY_AND_ASSIGN macro to delete copy and assignment constructors which uses c++11's rigorous function deletion on compilers that support it.