### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkArrivalFunctionToPathFilter.h
+++ b/include/itkArrivalFunctionToPathFilter.h
@@ -42,6 +42,8 @@ template <class TFilter>
 class ArrivalFunctionToPathCommand : public itk::Command
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ArrivalFunctionToPathCommand);
+
   /** Standard class type alias. */
   using Self = ArrivalFunctionToPathCommand;
   using Superclass = itk::Command;
@@ -82,8 +84,6 @@ protected:
   ~ArrivalFunctionToPathCommand() override{}
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ArrivalFunctionToPathCommand);
-
   typename FilterType::Pointer m_Filter;
 };
 
@@ -143,6 +143,8 @@ class ITK_EXPORT ArrivalFunctionToPathFilter :
     public ImageToPathFilter<TInputImage,TOutputPath>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ArrivalFunctionToPathFilter);
+
   /** Standard class type alias. */
   using Self = ArrivalFunctionToPathFilter;
   using Superclass = ImageToPathFilter<TInputImage,TOutputPath>;
@@ -235,9 +237,6 @@ protected:
   typename OptimizerType::MeasureType m_TerminationValue;
   std::vector<PointsContainerType> m_PointList;
   unsigned int m_CurrentOutput;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ArrivalFunctionToPathFilter);
 };
 
 } // end namespace itk

--- a/include/itkIterateNeighborhoodOptimizer.h
+++ b/include/itkIterateNeighborhoodOptimizer.h
@@ -41,6 +41,8 @@ class MinimalPathExtraction_EXPORT IterateNeighborhoodOptimizer :
     public SingleValuedNonLinearOptimizer
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(IterateNeighborhoodOptimizer);
+
   /** Standard class type alias. */
   using Self = IterateNeighborhoodOptimizer;
   using Superclass = SingleValuedNonLinearOptimizer;
@@ -108,8 +110,6 @@ protected:
   void PrintSelf(std::ostream& os, Indent indent) const override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(IterateNeighborhoodOptimizer);
-
   bool                 m_Stop;
   bool                 m_Maximize;
   bool                 m_FullyConnected;

--- a/include/itkPhysicalCentralDifferenceImageFunction.h
+++ b/include/itkPhysicalCentralDifferenceImageFunction.h
@@ -47,6 +47,8 @@ class ITK_EXPORT PhysicalCentralDifferenceImageFunction :
                         TCoordRep >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(PhysicalCentralDifferenceImageFunction);
+
   /** Dimension underlying input image. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 
@@ -136,8 +138,6 @@ protected:
   void PrintSelf(std::ostream& os, Indent indent) const override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhysicalCentralDifferenceImageFunction);
-
   typename InterpolateImageFunctionType::Pointer m_Interpolator;
 
 };

--- a/include/itkSingleImageCostFunction.h
+++ b/include/itkSingleImageCostFunction.h
@@ -53,6 +53,8 @@ class ITK_EXPORT SingleImageCostFunction :
     public SingleValuedCostFunction
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SingleImageCostFunction);
+
   /** Standard class type alias. */
   using Self = SingleImageCostFunction;
   using Superclass = SingleValuedCostFunction;
@@ -142,8 +144,6 @@ protected:
   void PrintSelf(std::ostream& os, Indent indent) const override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SingleImageCostFunction);
-
   ImageConstPointer                           m_Image;
   typename InterpolatorType::Pointer          m_Interpolator;
   typename GradientImageFunctionType::Pointer m_GradientImageFunction;

--- a/include/itkSpeedFunctionPathInformation.h
+++ b/include/itkSpeedFunctionPathInformation.h
@@ -53,6 +53,8 @@ class SpeedFunctionPathInformation :
   public LightObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SpeedFunctionPathInformation);
+
   /** Standard class type alias. */
   using Self = SpeedFunctionPathInformation;
   using Superclass = LightObject;
@@ -132,8 +134,6 @@ protected:
     V[0]=P;
     return(V);
   }
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SpeedFunctionPathInformation);
 };
 
 

--- a/include/itkSpeedFunctionToPathFilter.h
+++ b/include/itkSpeedFunctionToPathFilter.h
@@ -67,6 +67,8 @@ class ITK_EXPORT SpeedFunctionToPathFilter :
     public ArrivalFunctionToPathFilter<TInputImage,TOutputPath>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SpeedFunctionToPathFilter);
+
   /** Standard class type alias. */
   using Self = SpeedFunctionToPathFilter;
   using Superclass = ArrivalFunctionToPathFilter<TInputImage,TOutputPath>;
@@ -170,10 +172,6 @@ protected:
 
   std::vector< typename PathInformationType::Pointer > m_Information;
   InputImagePointer                                    m_CurrentArrivalFunction;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SpeedFunctionToPathFilter);
-
 };
 
 } // end namespace itk


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.