### PR TITLE
ENH: Build CI against ITK 4.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build-and-test:
     working_directory: /ITKMinimalPathExtraction-build
     docker:
-      - image: insighttoolkit/module-ci:latest
+      - image: insighttoolkit/module-ci:v4.13
     steps:
       - checkout:
           path: /ITKMinimalPathExtraction
@@ -50,6 +50,7 @@ jobs:
           name: Build Python packages
           no_output_timeout: 1.0h
           command: |
+            export ITK_PACKAGE_VERSION=v4.13.0
             ./dockcross-manylinux-download-cache-and-build-module-wheels.sh
       - store_artifacts:
           path: dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 script:
 - curl -L https://rawgit.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
 - chmod u+x macpython-download-cache-and-build-module-wheels.sh
+- export ITK_PACKAGE_VERSION=v4.13.0
 - ./macpython-download-cache-and-build-module-wheels.sh
 - tar -zcvf dist.tar.gz dist/
 - curl -F file="@dist.tar.gz" https://file.io

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ version: "0.0.1.{build}"
 install:
 
   - curl -L https://rawgit.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/windows-download-cache-and-build-module-wheels.ps1 -O
-  - ps: .\windows-download-cache-and-build-module-wheels.ps1
+  - ps: $env:ITK_PACKAGE_VERSION='v4.13.0'; .\windows-download-cache-and-build-module-wheels.ps1
 
 build: off
 


### PR DESCRIPTION
The default is currently ITK 5.0 alpha. Build against 4.13 so we can publish
Python packages to PyPI.