### PR TITLE
ENH: Fix vnl_math namespace resolution

### DIFF
--- a/include/itkSingleImageCostFunction.hxx
+++ b/include/itkSingleImageCostFunction.hxx
@@ -146,7 +146,7 @@ SingleImageCostFunction<TImage>
     //           (indicated by very large values) which may skew the gradient.
     //           To avoid this skewing effect, we reset gradient values larger
     //           than a given threshold.
-    if ( vnl_math_abs(derivative[i]) > DerivativeThreshold )
+    if ( vnl_math::abs(derivative[i]) > DerivativeThreshold )
       {
       derivative[i] = 0.0;
       }


### PR DESCRIPTION
vnl_math_XXX has become vnl_math:: as a proper namespace.