### PR TITLE
COMP: Future proof vnl_math_XXX function usage.

### DIFF
--- a/include/itkArrivalFunctionToPathFilter.hxx
+++ b/include/itkArrivalFunctionToPathFilter.hxx
@@ -18,7 +18,7 @@
 #ifndef itkArrivalFunctionToPathFilter_hxx
 #define itkArrivalFunctionToPathFilter_hxx
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "itkArrivalFunctionToPathFilter.h"
 
 namespace itk

--- a/include/itkSingleImageCostFunction.hxx
+++ b/include/itkSingleImageCostFunction.hxx
@@ -17,7 +17,7 @@
 #ifndef itkSingleImageCostFunction_hxx
 #define itkSingleImageCostFunction_hxx
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "itkSingleImageCostFunction.h"
 
 namespace itk
@@ -146,7 +146,7 @@ SingleImageCostFunction<TImage>
     //           (indicated by very large values) which may skew the gradient.
     //           To avoid this skewing effect, we reset gradient values larger
     //           than a given threshold.
-    if ( vnl_math::abs(derivative[i]) > DerivativeThreshold )
+    if ( itk::Math::abs (derivative[i]) > DerivativeThreshold )
       {
       derivative[i] = 0.0;
       }

--- a/include/itkSpeedFunctionToPathFilter.hxx
+++ b/include/itkSpeedFunctionToPathFilter.hxx
@@ -18,7 +18,7 @@
 #ifndef itkSpeedFunctionToPathFilter_hxx
 #define itkSpeedFunctionToPathFilter_hxx
 
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 #include "itkSpeedFunctionToPathFilter.h"
 #include "itkFastMarchingUpwindGradientImageFilter.h"
 


### PR DESCRIPTION
Prefer C++ over aliased names vnl_math_[min|max] -> std::[min|max]
Prefer vnl_math::abs over deprecated alias vnl_math_abs

In all compilers currently supported by VXL, vnl_math_[min|max]
could be replaced with std::[min|max] without loss of
functionality.  This also circumvents part of the backwards
compatibility requirements as vnl_math_ has been recently
replaced with a namespace of vnl_math::.

Since Wed Nov 14 07:42:48 2012:
The vnl_math_* functions use #define aliases to their
vnl_math::* counterparts in the "real" vnl_math:: namespace.

The new syntax should be backwards compatible to
VXL versions as old as 2012.

Prefer to use itk::Math:: over vnl_math:: namespace