### PR TITLE
BUG: Fix `itksys::SystemTools`-related return types/subscripts.

### DIFF
--- a/test/MinimalPathTest.h
+++ b/test/MinimalPathTest.h
@@ -89,19 +89,19 @@ int ReadPathFile( const char * PathFilename, typename PathFilterType::Pointer pa
             itksys::SystemTools::ReplaceString( line, "Path: ", "" );
             itksys::SystemTools::ReplaceString( line, " ", "" );
             itksys::SystemTools::ReplaceString( line, "[", "" );
-            std::vector<itksys::String> parts;
+            std::vector<std::string> parts;
             parts = itksys::SystemTools::SplitString( line.c_str(), ']' );
-            unsigned int numNonNullParts = 0;
+            size_type numNonNullParts = 0;
             for (auto & part : parts)
                 if ( part.length() != 0 ) numNonNullParts++;
-            for (unsigned int i=0; i<numNonNullParts; i++)
+            for (size_type i=0; i<numNonNullParts; i++)
             {
                 if ( parts[i].length() != 0 )
                 {
                     typename PathFilterType::PointType point;
-                    std::vector<itksys::String> partsPoint;
+                    std::vector<std::string> partsPoint;
                     partsPoint = itksys::SystemTools::SplitString( parts[i].c_str(), ',' );
-                    for (unsigned int j=0; j<partsPoint.size(); j++)
+                    for (size_type j=0; j<partsPoint.size(); j++)
                         point[j] = std::stod( partsPoint[j].c_str() );
                     if ( i==0 ) info->SetStartPoint( point );
                     else if ( i == numNonNullParts - 1 ) info->SetEndPoint( point );


### PR DESCRIPTION
Fix `itksys::SystemTools`-related string return types and related `[]`
operator subscript types. Fixes:
```
Modules/Remote/MinimalPathExtraction/test/MinimalPathTest.h:92:25: error:
'String' is not a member of 'itksys'
std::vector<itksys::String> parts;
                         ^
```
and
```
Modules/Remote/MinimalPathExtraction/test/MinimalPathTest.h:99:29: error:
invalid types 'int[unsigned int]' for array subscript
if ( parts[i].length() != 0 )
            ^
```

reported at:
http://testing.cdash.org/viewBuildError.php?buildid=5792664