### PR TITLE
COMP: Use auto to handle changing return type of SplitString

### DIFF
--- a/test/MinimalPathTest.h
+++ b/test/MinimalPathTest.h
@@ -89,7 +89,7 @@ int ReadPathFile( const char * PathFilename, typename PathFilterType::Pointer pa
             itksys::SystemTools::ReplaceString( line, "Path: ", "" );
             itksys::SystemTools::ReplaceString( line, " ", "" );
             itksys::SystemTools::ReplaceString( line, "[", "" );
-            std::vector<std::string> parts = itksys::SystemTools::SplitString( line, ']' );
+            auto parts = itksys::SystemTools::SplitString( line, ']' );
             std::vector<std::string>::size_type numNonNullParts = 0;
             for (auto & part : parts)
                 if ( part.length() != 0 ) numNonNullParts++;
@@ -98,7 +98,7 @@ int ReadPathFile( const char * PathFilename, typename PathFilterType::Pointer pa
                 if ( parts[i].length() != 0 )
                 {
                     typename PathFilterType::PointType point;
-                    std::vector<std::string> partsPoint = itksys::SystemTools::SplitString( parts[i], ',' );
+                    auto partsPoint = itksys::SystemTools::SplitString( parts[i], ',' );
                     for (std::vector<std::string>::size_type j=0; j<partsPoint.size(); j++)
                         point[j] = std::stod( partsPoint[j].c_str() );
                     if ( i==0 ) info->SetStartPoint( point );


### PR DESCRIPTION
To address:

  est/MinimalPathTest.h:92:90: error: conversion from 'std::vector<itksys::String>' to non-scalar type 'std::vector<std::__cxx11::basic_string<char> >' requested