### PR TITLE
DOC: TerminationValue is 1.0 by default (not 0.0)

### DIFF
--- a/include/itkArrivalFunctionToPathFilter.h
+++ b/include/itkArrivalFunctionToPathFilter.h
@@ -204,7 +204,7 @@ public:
 
   /** Get/set the termination. Once the current optimizer value falls below
    *  TerminationValue, no further points will be appended to the path.
-   *  The default value is 0.0. */
+   *  The default value is 1.0. */
   itkSetMacro(TerminationValue, typename OptimizerType::MeasureType);
   itkGetMacro(TerminationValue, typename OptimizerType::MeasureType);
 


### PR DESCRIPTION
see: https://github.com/InsightSoftwareConsortium/ITKMinimalPathExtraction/blob/f658f822646ac6b2755b23ab99b58c8b38eeda68/include/itkArrivalFunctionToPathFilter.hxx#L31