### PR TITLE
BUG: Replace include of itkExceptionObject.h with itkMacro.h

### DIFF
--- a/include/itkSingleImageCostFunction.h
+++ b/include/itkSingleImageCostFunction.h
@@ -18,7 +18,7 @@
 #define itkSingleImageCostFunction_h
 
 #include "itkNumericTraits.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 #include "itkContinuousIndex.h"
 #include "itkSingleValuedCostFunction.h"
 #include "itkInterpolateImageFunction.h"

--- a/src/itkIterateNeighborhoodOptimizer.cxx
+++ b/src/itkIterateNeighborhoodOptimizer.cxx
@@ -18,7 +18,7 @@
 #include "itkIterateNeighborhoodOptimizer.h"
 #include "itkCommand.h"
 #include "itkEventObject.h"
-#include "itkExceptionObject.h"
+#include "itkMacro.h"
 
 namespace itk
 {


### PR DESCRIPTION
ITKv5 prohibits including itkExceptionObject.h directly and recommends
including itkMacro.h.   With proper CMake options set, including
itkExceptionObject.h will cause a compilation error.