### PR TITLE
COMP: C++11 has deprecated the "throw" function declaration decorator

### DIFF
--- a/include/itkSingleImageCostFunction.h
+++ b/include/itkSingleImageCostFunction.h
@@ -115,7 +115,7 @@ public:
   itkGetConstReferenceMacro( DerivativeThreshold, DerivativeType::ValueType );
 
   /** Initialize the cost function */
-  virtual void Initialize(void) throw ( ExceptionObject );
+  virtual void Initialize(void);
 
   /** Return the number of parameters required by the Transform */
   unsigned int GetNumberOfParameters(void) const override

--- a/include/itkSingleImageCostFunction.hxx
+++ b/include/itkSingleImageCostFunction.hxx
@@ -43,7 +43,7 @@ SingleImageCostFunction<TImage>
 template <class TImage>
 void
 SingleImageCostFunction<TImage>
-::Initialize(void) throw ( ExceptionObject )
+::Initialize(void)
 {
   // Ensure image is provided
   if( !m_Image )


### PR DESCRIPTION
When declaring functions in .h files and defining them (e.g., in .hxx
files), C++11 has deprecated the use of "throw(exception)" in the
function declaration statements.  The message is

```
warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
 ::Initialize(void) throw ( ExceptionObject )
                    ^~~~~
```