### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkArrivalFunctionToPathFilter.h
+++ b/include/itkArrivalFunctionToPathFilter.h
@@ -43,7 +43,7 @@ template <typename TFilter>
 class ITK_TEMPLATE_EXPORT ArrivalFunctionToPathCommand : public itk::Command
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ArrivalFunctionToPathCommand);
+  ITK_DISALLOW_COPY_AND_MOVE(ArrivalFunctionToPathCommand);
 
   /** Standard class type alias. */
   using Self = ArrivalFunctionToPathCommand;
@@ -145,7 +145,7 @@ template <typename TInputImage, typename TOutputPath = PolyLineParametricPath<TI
 class ITK_TEMPLATE_EXPORT ArrivalFunctionToPathFilter : public ImageToPathFilter<TInputImage, TOutputPath>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ArrivalFunctionToPathFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ArrivalFunctionToPathFilter);
 
   /** Standard class type alias. */
   using Self = ArrivalFunctionToPathFilter;

--- a/include/itkIterateNeighborhoodOptimizer.h
+++ b/include/itkIterateNeighborhoodOptimizer.h
@@ -41,7 +41,7 @@ namespace itk
 class MinimalPathExtraction_EXPORT IterateNeighborhoodOptimizer : public SingleValuedNonLinearOptimizer
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(IterateNeighborhoodOptimizer);
+  ITK_DISALLOW_COPY_AND_MOVE(IterateNeighborhoodOptimizer);
 
   /** Standard class type alias. */
   using Self = IterateNeighborhoodOptimizer;

--- a/include/itkPhysicalCentralDifferenceImageFunction.h
+++ b/include/itkPhysicalCentralDifferenceImageFunction.h
@@ -44,7 +44,7 @@ class ITK_TEMPLATE_EXPORT PhysicalCentralDifferenceImageFunction
   : public ImageFunction<TInputImage, CovariantVector<double, TInputImage::ImageDimension>, TCoordRep>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhysicalCentralDifferenceImageFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(PhysicalCentralDifferenceImageFunction);
 
   /** Dimension underlying input image. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;

--- a/include/itkSingleImageCostFunction.h
+++ b/include/itkSingleImageCostFunction.h
@@ -53,7 +53,7 @@ template <typename TImage>
 class ITK_TEMPLATE_EXPORT SingleImageCostFunction : public SingleValuedCostFunction
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SingleImageCostFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(SingleImageCostFunction);
 
   /** Standard class type alias. */
   using Self = SingleImageCostFunction;

--- a/include/itkSpeedFunctionPathInformation.h
+++ b/include/itkSpeedFunctionPathInformation.h
@@ -53,7 +53,7 @@ template <typename TPoint>
 class ITK_TEMPLATE_EXPORT SpeedFunctionPathInformation : public LightObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SpeedFunctionPathInformation);
+  ITK_DISALLOW_COPY_AND_MOVE(SpeedFunctionPathInformation);
 
   /** Standard class type alias. */
   using Self = SpeedFunctionPathInformation;

--- a/include/itkSpeedFunctionToPathFilter.h
+++ b/include/itkSpeedFunctionToPathFilter.h
@@ -69,7 +69,7 @@ template <typename TInputImage, typename TOutputPath = PolyLineParametricPath<TI
 class ITK_TEMPLATE_EXPORT SpeedFunctionToPathFilter : public ArrivalFunctionToPathFilter<TInputImage, TOutputPath>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SpeedFunctionToPathFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(SpeedFunctionToPathFilter);
 
   /** Standard class type alias. */
   using Self = SpeedFunctionToPathFilter;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.