### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkArrivalFunctionToPathFilter.hxx
+++ b/include/itkArrivalFunctionToPathFilter.hxx
@@ -20,7 +20,6 @@
 #define itkArrivalFunctionToPathFilter_hxx
 
 #include "itkMath.h"
-#include "itkArrivalFunctionToPathFilter.h"
 
 namespace itk
 {

--- a/include/itkPhysicalCentralDifferenceImageFunction.hxx
+++ b/include/itkPhysicalCentralDifferenceImageFunction.hxx
@@ -18,7 +18,6 @@
 #ifndef itkPhysicalCentralDifferenceImageFunction_hxx
 #define itkPhysicalCentralDifferenceImageFunction_hxx
 
-#include "itkPhysicalCentralDifferenceImageFunction.h"
 
 namespace itk
 {

--- a/include/itkSingleImageCostFunction.hxx
+++ b/include/itkSingleImageCostFunction.hxx
@@ -19,7 +19,6 @@
 #define itkSingleImageCostFunction_hxx
 
 #include "itkMath.h"
-#include "itkSingleImageCostFunction.h"
 
 namespace itk
 {

--- a/include/itkSpeedFunctionPathInformation.hxx
+++ b/include/itkSpeedFunctionPathInformation.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSpeedFunctionPathInformation_hxx
 #define itkSpeedFunctionPathInformation_hxx
 
-#include "itkSpeedFunctionPathInformation.h"
 
 namespace itk
 {

--- a/include/itkSpeedFunctionToPathFilter.hxx
+++ b/include/itkSpeedFunctionToPathFilter.hxx
@@ -19,7 +19,6 @@
 #define itkSpeedFunctionToPathFilter_hxx
 
 #include "itkMath.h"
-#include "itkSpeedFunctionToPathFilter.h"
 #include "itkFastMarchingUpwindGradientImageFilter.h"
 
 


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

