### PR TITLE
BUG: Set FastMarching targets prior to reach mode

### DIFF
--- a/include/itkSpeedFunctionToPathFilter.hxx
+++ b/include/itkSpeedFunctionToPathFilter.hxx
@@ -67,7 +67,6 @@ SpeedFunctionToPathFilter<TInputImage, TOutputPath>::ComputeArrivalFunction()
   marching->SetInput(speed);
   marching->SetGenerateGradientImage(false);
   marching->SetTargetOffset(2.0 * Superclass::m_TerminationValue);
-  marching->SetTargetReachedModeToAllTargets();
 
   // Add next and previous front sources as target points to
   // limit the front propagation to just the required zones
@@ -101,6 +100,8 @@ SpeedFunctionToPathFilter<TInputImage, TOutputPath>::ComputeArrivalFunction()
     targets->InsertElement(1, nodeTargetNext);
   }
   marching->SetTargetPoints(targets);
+
+  marching->SetTargetReachedModeToAllTargets();
 
   // Get the next Front source point and add as trial point
   typename NodeContainer::Pointer trial = NodeContainer::New();


### PR DESCRIPTION
With updates to FastMarching in ITK, it is necessary to
SetTargetPoints prior to setting TargetReachMode.

Without this change, an exception is thrown in
itkFastMarchingUpwindGradientImageFilter::
VerifyTargetReachedModeConditions() when called by
SetTargetReachedModeToAllTargets()
which is called by itkSpeedfunctionToPathFilter::
ComputeArrivalFunction()