### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkArrivalFunctionToPathFilter.h
+++ b/include/itkArrivalFunctionToPathFilter.h
@@ -154,7 +154,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ArrivalFunctionToPathFilter, ImageToPathFilter);
+  itkOverrideGetNameOfClassMacro(ArrivalFunctionToPathFilter);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkIterateNeighborhoodOptimizer.h
+++ b/include/itkIterateNeighborhoodOptimizer.h
@@ -53,7 +53,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(IterateNeighborhoodOptimizer, SingleValuedNonLinearOptimizer);
+  itkOverrideGetNameOfClassMacro(IterateNeighborhoodOptimizer);
 
   /** Configure whether the local maxima or minima is found.
    *  The default is to minimize the cost function (maximize = false ).*/

--- a/include/itkPhysicalCentralDifferenceImageFunction.h
+++ b/include/itkPhysicalCentralDifferenceImageFunction.h
@@ -57,7 +57,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PhysicalCentralDifferenceImageFunction, ImageFunction);
+  itkOverrideGetNameOfClassMacro(PhysicalCentralDifferenceImageFunction);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkSingleImageCostFunction.h
+++ b/include/itkSingleImageCostFunction.h
@@ -65,7 +65,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SingleImageCostFunction, SingleValuedCostFunction);
+  itkOverrideGetNameOfClassMacro(SingleImageCostFunction);
 
   /** MeasureType type alias.
    *  It defines a type used to return the cost function value. */

--- a/include/itkSpeedFunctionPathInformation.h
+++ b/include/itkSpeedFunctionPathInformation.h
@@ -63,7 +63,7 @@ public:
 
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SpeedFunctionPathInformation, LightObject);
+  itkOverrideGetNameOfClassMacro(SpeedFunctionPathInformation);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkSpeedFunctionToPathFilter.h
+++ b/include/itkSpeedFunctionToPathFilter.h
@@ -78,7 +78,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SpeedFunctionToPathFilter, ArrivalFunctionToPathFilter);
+  itkOverrideGetNameOfClassMacro(SpeedFunctionToPathFilter);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
