### PR TITLE
Update to ITK v5.4.2 support system

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -4,9 +4,9 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.2
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.2
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "itk-minimalpathextraction"
-version = "2.0.0"
+version = "2.0.1"
 description = "A minimal path extraction framework based on Fast Marching arrival functions."
 readme = "README.rst"
 license = {file = "LICENSE"}
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "itk == 5.4.*",
 ]


### PR DESCRIPTION
Ensure that cmake is 3.16.3 or greater to
match v5.4.2 minimum requirements.

Set minimum python to 3.9

Increment version number.

Replace keyword of "ITK" with lowercase "itk"
in some instances to be consistent.

Set the default build package tags to v5.4.2
for capturing the ITKRemoteModuleBuildTestPackageAction
shared scripts.

This pulls the default configuration items needed
to build against ITK version v5.4.2.
